### PR TITLE
Add basic context definitions

### DIFF
--- a/queries/context.scm
+++ b/queries/context.scm
@@ -5,3 +5,4 @@
 (for_statement) @context
 (enum_declaration) @context
 (struct_declaration) @context
+(while_statement) @context

--- a/queries/context.scm
+++ b/queries/context.scm
@@ -1,0 +1,7 @@
+(procedure_declaration) @context
+(static_if_statement) @context
+(if_statement) @context
+(else_clause) @context
+(for_statement) @context
+(enum_declaration) @context
+(struct_declaration) @context


### PR DESCRIPTION
Hi. I added some context definitions for treesitter context. They can be used with [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context/tree/master).