### PR TITLE
fix: int literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1183,9 +1183,9 @@ module.exports = grammar({
 
         integer: _ =>
             choice(
-                token(seq(choice("0b", "0B"), BIN_INT)),
-                token(seq(choice("0o", "0O"), OCT_INT)),
-                token(seq(choice("0x", "0X"), HEX_INT)),
+                token(seq('0', choice("b", "B"), optional('_'), BIN_INT)),
+                token(seq('0', choice("o", "O"), optional('_'), OCT_INT)),
+                token(seq('0', choice("x", "X"), optional('_'), HEX_INT)),
                 token(DEC_INT),
             ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6942,15 +6942,31 @@
             "type": "SEQ",
             "members": [
               {
+                "type": "STRING",
+                "value": "0"
+              },
+              {
                 "type": "CHOICE",
                 "members": [
                   {
                     "type": "STRING",
-                    "value": "0b"
+                    "value": "b"
                   },
                   {
                     "type": "STRING",
-                    "value": "0B"
+                    "value": "B"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "_"
+                  },
+                  {
+                    "type": "BLANK"
                   }
                 ]
               },
@@ -6996,15 +7012,31 @@
             "type": "SEQ",
             "members": [
               {
+                "type": "STRING",
+                "value": "0"
+              },
+              {
                 "type": "CHOICE",
                 "members": [
                   {
                     "type": "STRING",
-                    "value": "0o"
+                    "value": "o"
                   },
                   {
                     "type": "STRING",
-                    "value": "0O"
+                    "value": "O"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "_"
+                  },
+                  {
+                    "type": "BLANK"
                   }
                 ]
               },
@@ -7050,15 +7082,31 @@
             "type": "SEQ",
             "members": [
               {
+                "type": "STRING",
+                "value": "0"
+              },
+              {
                 "type": "CHOICE",
                 "members": [
                   {
                     "type": "STRING",
-                    "value": "0x"
+                    "value": "x"
                   },
                   {
                     "type": "STRING",
-                    "value": "0X"
+                    "value": "X"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "_"
+                  },
+                  {
+                    "type": "BLANK"
                   }
                 ]
               },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -859,6 +859,7 @@
   {
     "type": "block_comment",
     "named": true,
+    "extra": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -1082,6 +1083,7 @@
   {
     "type": "comment",
     "named": true,
+    "extra": true,
     "fields": {}
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,7 +18,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata TSLanguageMetadata;
 typedef struct TSLanguageMetadata {
   uint8_t major_version;
   uint8_t minor_version;

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1,0 +1,62 @@
+================================================================================
+int literals
+================================================================================
+
+i1 :: 42;
+i2 :: 4_2;
+i3 :: 0600;
+i4 :: 0_600;
+i5 :: 0b101;
+i6 :: 0B101;
+i7 :: 0xBadFace;
+i8 :: 0xBad_Face;
+i9 :: 0x_67_7a_2f_cc_40_c6;
+
+--------------------------------------------------------------------------------
+
+(source_file
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer))))
+	(top_level_declarations
+		(declarations_that_require_a_semicolon
+			(const_declaration
+				(identifier)
+				(integer)))))


### PR DESCRIPTION
- Adds int literals to the test corpus
- Fixes case where leading _ was failing to parse
	- example int literal `i9`