### PR TITLE
Fix: make `tree-sitter highlight` cli command works

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -240,13 +240,16 @@ keyword: (identifier) @keyword
 [
   (block_comment)
   (comment)
-] @comment @spell
+] @spell
+
+[
+  (block_comment)
+  (comment)
+] @comment 
 
 ; Errors
 
 (ERROR) @error
-
-(block_comment) @comment
 
 directive: ("#") @keyword ; #if
 type: ("type_of") @type

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -5,7 +5,8 @@
       "camelcase": "Jai",
       "scope": "source.jai",
       "path": ".",
-      "file-types": null,
+      "file-types": ["jai"],
+      "highlights": "queries/highlights.scm",
       "injection-regex": "^jai$"
     }
   ],


### PR DESCRIPTION
When trying to use the syntax highlighting using tree-sitter cli `tree-sitter highlight how_to/001_first.jai`, I encountered a few issues. This PR does the following to fix those:
- In `tree-sitter.json`, adds `file-types` configuration, so that the cli knows which file extension is jai extension.
- In `tree-sitter.json`, adds `highlights` path configuration. Technically, the default value is already correct, however the cli emits a warning to add the `highlights` query path. This fix is only to suppress the warning.
- In `queries/highlights.scm`: separate `@spell` and `@comment` capture. Previously, the cli doesn't highlight the inline comment, only block comment.