### PR TITLE
Increase highlight priority for types

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -116,7 +116,11 @@ named_argument: (identifier) @variable
 
 type: (types) @type
 type: (identifier) @type
-((types) @type)
+
+; Slightly increase the priority so types like `[5] int` and `*float` render fully as types
+; rather than punctuation.bracket + type or operator + type, respectively
+((types) @type
+         (#set! "priority" 105))
 
 modifier: (identifier) @keyword
 keyword: (identifier) @keyword


### PR DESCRIPTION
The goal here was to highlight the full type consistently rather than equal-weighted rendering of several components, e.g., `[5] int` and `*float` will render uniformly as a type highlight as opposed to combinations of brackets, constant, and operator + type.

Worth calling out here that some folks may prefer the current behavior, which I suspect will mostly be true in cases like `[MY_MAX] float`. At any rate, sharing in case upstream agrees with my preference.

**Before:**
<img width="488" height="272" alt="before" src="https://github.com/user-attachments/assets/120b330c-db2e-42fb-b9ab-8c6d2f3097d6" />



**After:**
<img width="484" height="271" alt="after" src="https://github.com/user-attachments/assets/2aa66e1e-2a75-475c-ba66-b27e2b5a0db0" />
