### PR TITLE
add tagged union syntax handling

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -337,10 +337,28 @@ module.exports = grammar({
         struct_or_union: $ => seq(
             choice('struct', 'union'),
             optional($.compiler_directive),
+            optional($.tagged_union_kind),
             // Parameterized structs
             field('modifier', optional($.named_parameters)),
             optional($.modify_block),
             $.struct_or_union_block,
+        ),
+
+        tagged_union_kind: $ => seq(
+            field('name', $.identifier),
+            ':',
+            field('type', $.types),
+        ),
+
+        tagged_union_field: $ => seq(
+            '.',
+            field('tag', $.identifier),
+            ',,',
+            optional(seq(
+                $.variable_declaration,
+                optional($.align_directive),
+            )),
+            ';',
         ),
 
         struct_or_union_block: $ => prec.left(seq(
@@ -356,11 +374,12 @@ module.exports = grammar({
                 $.struct_or_union,
                 $.static_if_statement,
                 $.using_statement,
+                $.tagged_union_field,
                 ';',
                 seq(
                     choice(
                         $.insert_statement,
-                        $.const_declaration,   
+                        $.const_declaration,
                         $.assignment_statement,
                         $.variable_declaration,
                         $.place_directive,
@@ -1035,6 +1054,7 @@ module.exports = grammar({
             //  variable : struct {} = .{};
             choice('struct', 'union'),
             optional($.compiler_directive),
+            optional($.tagged_union_kind),
 
             // Also valid in terms that the compiler will not complain, but
             // useless since you cannot put anything inside the parentheses:

--- a/grammar.js
+++ b/grammar.js
@@ -350,7 +350,7 @@ module.exports = grammar({
             field('type', $.types),
         ),
 
-        tagged_union_field: $ => seq(
+        tagged_union_binding: $ => seq(
             '.',
             field('tag', $.identifier),
             ',,',
@@ -374,7 +374,7 @@ module.exports = grammar({
                 $.struct_or_union,
                 $.static_if_statement,
                 $.using_statement,
-                $.tagged_union_field,
+                $.tagged_union_binding,
                 ';',
                 seq(
                     choice(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -251,7 +251,7 @@ keyword: (identifier) @keyword
 
 (tagged_union_kind name: (identifier) @keyword)
 
-(tagged_union_field tag: (identifier) @constant)
+(tagged_union_binding tag: (identifier) @constant)
 
 ",," @operator
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -247,6 +247,14 @@ keyword: (identifier) @keyword
   (comment)
 ] @comment 
 
+; Tagged unions
+
+(tagged_union_kind name: (identifier) @keyword)
+
+(tagged_union_field tag: (identifier) @constant)
+
+",," @operator
+
 ; Errors
 
 (ERROR) @error

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1328,7 +1328,7 @@
         }
       ]
     },
-    "tagged_union_field": {
+    "tagged_union_binding": {
       "type": "SEQ",
       "members": [
         {
@@ -1451,7 +1451,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "tagged_union_field"
+                      "name": "tagged_union_binding"
                     },
                     {
                       "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1258,6 +1258,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "tagged_union_kind"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "FIELD",
           "name": "modifier",
           "content": {
@@ -1288,6 +1300,85 @@
         {
           "type": "SYMBOL",
           "name": "struct_or_union_block"
+        }
+      ]
+    },
+    "tagged_union_kind": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "types"
+          }
+        }
+      ]
+    },
+    "tagged_union_field": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "FIELD",
+          "name": "tag",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ",,"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "variable_declaration"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "align_directive"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -1357,6 +1448,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "using_statement"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "tagged_union_field"
                     },
                     {
                       "type": "STRING",
@@ -6036,6 +6131,18 @@
               {
                 "type": "SYMBOL",
                 "name": "compiler_directive"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "tagged_union_kind"
               },
               {
                 "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -381,6 +381,10 @@
         {
           "type": "struct_or_union_block",
           "named": true
+        },
+        {
+          "type": "tagged_union_kind",
+          "named": true
         }
       ]
     }
@@ -3077,6 +3081,10 @@
         {
           "type": "struct_or_union_block",
           "named": true
+        },
+        {
+          "type": "tagged_union_kind",
+          "named": true
         }
       ]
     }
@@ -3153,6 +3161,10 @@
           "named": true
         },
         {
+          "type": "tagged_union_field",
+          "named": true
+        },
+        {
           "type": "using_statement",
           "named": true
         },
@@ -3191,6 +3203,62 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "tagged_union_field",
+    "named": true,
+    "fields": {
+      "tag": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "align_directive",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "tagged_union_kind",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "types",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3634,6 +3702,10 @@
   },
   {
     "type": ",",
+    "named": false
+  },
+  {
+    "type": ",,",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3161,7 +3161,7 @@
           "named": true
         },
         {
-          "type": "tagged_union_field",
+          "type": "tagged_union_binding",
           "named": true
         },
         {
@@ -3206,7 +3206,7 @@
     }
   },
   {
-    "type": "tagged_union_field",
+    "type": "tagged_union_binding",
     "named": true,
     "fields": {
       "tag": {


### PR DESCRIPTION
Using the new tagged union syntax can break syntax highlighting - see screenshots below for demonstration.

Current issues with highlighting tagged unions:
<img width="793" height="630" alt="Screenshot 2026-05-14 at 10 28 28 PM" src="https://github.com/user-attachments/assets/fee31602-94ee-4dbe-b6e9-16b99b0410cd" />

After these changes:
<img width="686" height="629" alt="image" src="https://github.com/user-attachments/assets/da14d81d-eafd-4e3f-bb6c-6dfef4660f26" />
