### PR TITLE
fix nested assignment in struct literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1121,7 +1121,8 @@ module.exports = grammar({
                     optional(seq(field('name',
                         choice(
                             $.identifier,
-                            $.index_expression // maybe there are more cases like this
+                            $.index_expression, // maybe there are more cases like this
+                            $.member_expression // support cases like foo.bar = ...
                         )
                     ), '=')), // named
                     $.expressions,

--- a/grammar_test.jai
+++ b/grammar_test.jai
@@ -96,6 +96,13 @@ TestStruct2 :: struct (type: Type = s64) {
     next: *Test_Struct2;
 }
 
+TestStruct3 :: struct {
+    a: struct {
+        b: int;
+    }
+    c: float;
+}
+
 TestEnum :: enum { A; B; }
 test_enum: enum {
     A;
@@ -147,6 +154,7 @@ main :: () {
 
     struct_literal1 := TestStruct1.{}
     struct_literal2 := TestStruct2(69).{}
+    struct_literal3 := TestStruct3.{ a.b = 420, c = 1337 }
 
     //        Parameterized struct type
     struct1 : TestStruct2(420, 540, 999, "perhaps") = .{420, 540, 999, "perhaps"};

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6482,6 +6482,10 @@
                                           {
                                             "type": "SYMBOL",
                                             "name": "index_expression"
+                                          },
+                                          {
+                                            "type": "SYMBOL",
+                                            "name": "member_expression"
                                           }
                                         ]
                                       }
@@ -6538,6 +6542,10 @@
                                                 {
                                                   "type": "SYMBOL",
                                                   "name": "index_expression"
+                                                },
+                                                {
+                                                  "type": "SYMBOL",
+                                                  "name": "member_expression"
                                                 }
                                               ]
                                             }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3008,6 +3008,10 @@
           {
             "type": "index_expression",
             "named": true
+          },
+          {
+            "type": "member_expression",
+            "named": true
           }
         ]
       },

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -52,96 +52,67 @@ extern "C" {
 
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity)        \
-  ((self)->contents = _array__reserve(           \
-    (void *)(self)->contents, &(self)->capacity, \
-    array_elem_size(self), new_capacity)         \
-  )
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
 
 /// Free any memory allocated for this array. Note that this does not free any
 /// memory allocated for the array's contents.
-#define array_delete(self)                           \
-  do {                                               \
-    if ((self)->contents) ts_free((self)->contents); \
-    (self)->contents = NULL;                         \
-    (self)->size = 0;                                \
-    (self)->capacity = 0;                            \
-  } while (0)
+#define array_delete(self) _array__delete((Array *)(self))
 
 /// Push a new `element` onto the end of the array.
-#define array_push(self, element)                                 \
-  do {                                                            \
-    (self)->contents = _array__grow(                              \
-      (void *)(self)->contents, (self)->size, &(self)->capacity,  \
-      1, array_elem_size(self)                                    \
-    );                                                            \
-   (self)->contents[(self)->size++] = (element);                  \
-  } while(0)
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
 
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
-#define array_grow_by(self, count)                                               \
-  do {                                                                           \
-    if ((count) == 0) break;                                                     \
-    (self)->contents = _array__grow(                                             \
-      (self)->contents, (self)->size, &(self)->capacity,                         \
-      count, array_elem_size(self)                                               \
-    );                                                                           \
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
-    (self)->size += (count);                                                     \
+    (self)->size += (count); \
   } while (0)
 
 /// Append all elements from one array to the end of another.
-#define array_push_all(self, other) \
+#define array_push_all(self, other)                                       \
   array_extend((self), (other)->size, (other)->contents)
 
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
-#define array_extend(self, count, other_contents)                 \
-  (self)->contents = _array__splice(                              \
-    (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
-    array_elem_size(self), (self)->size, 0, count, other_contents \
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
   )
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
-#define array_splice(self, _index, old_count, new_count, new_contents) \
-  (self)->contents = _array__splice(                                   \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
-    array_elem_size(self), _index, old_count, new_count, new_contents  \
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
   )
 
 /// Insert one `element` into the array at the given `index`.
-#define array_insert(self, _index, element)                     \
-  (self)->contents = _array__splice(                            \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity, \
-    array_elem_size(self), _index, 0, 1, &(element)             \
-  )
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
-  _array__erase((void *)(self)->contents, &(self)->size, array_elem_size(self), _index)
+  _array__erase((Array *)(self), array_elem_size(self), _index)
 
 /// Pop the last element off the array, returning the element by value.
 #define array_pop(self) ((self)->contents[--(self)->size])
 
 /// Assign the contents of one array to another, reallocating if necessary.
-#define array_assign(self, other)                                   \
-  (self)->contents = _array__assign(                                \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
-    (const void *)(other)->contents, (other)->size, array_elem_size(self) \
-  )
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
 
 /// Swap one array with another
-#define array_swap(self, other)                                     \
-  do {                                                              \
-    void *_array_swap_tmp = (void *)(self)->contents;               \
-    (self)->contents = (other)->contents;                           \
-    (other)->contents = _array_swap_tmp;                            \
-    _array__swap(&(self)->size, &(self)->capacity,                  \
-                 &(other)->size, &(other)->capacity);               \
-  } while (0)
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
 
 /// Get the size of the array contents
 #define array_elem_size(self) (sizeof *(self)->contents)
@@ -186,90 +157,82 @@ extern "C" {
 
 // Private
 
-// Pointers to individual `Array` fields (rather than the entire `Array` itself)
-// are passed to the various `_array__*` functions below to address strict aliasing
-// violations that arises when the _entire_ `Array` struct is passed as `Array(void)*`.
-//
-// The `Array` type itself was not altered as a solution in order to avoid breakage
-// with existing consumers (in particular, parsers with external scanners).
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
 
 /// This is not what you're looking for, see `array_erase`.
-static inline void _array__erase(void* self_contents, uint32_t *size,
-                                size_t element_size, uint32_t index) {
-  assert(index < *size);
-  char *contents = (char *)self_contents;
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
-          (*size - index - 1) * element_size);
-  (*size)--;
+          (self->size - index - 1) * element_size);
+  self->size--;
 }
 
 /// This is not what you're looking for, see `array_reserve`.
-static inline void *_array__reserve(void *contents, uint32_t *capacity,
-                                  size_t element_size, uint32_t new_capacity) {
-  void *new_contents = contents;
-  if (new_capacity > *capacity) {
-    if (contents) {
-      new_contents = ts_realloc(contents, new_capacity * element_size);
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
     } else {
-      new_contents = ts_malloc(new_capacity * element_size);
+      self->contents = ts_malloc(new_capacity * element_size);
     }
-    *capacity = new_capacity;
+    self->capacity = new_capacity;
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_assign`.
-static inline void *_array__assign(void* self_contents, uint32_t *self_size, uint32_t *self_capacity,
-                                 const void *other_contents, uint32_t other_size, size_t element_size) {
-  void *new_contents = _array__reserve(self_contents, self_capacity, element_size, other_size);
-  *self_size = other_size;
-  memcpy(new_contents, other_contents, *self_size * element_size);
-  return new_contents;
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
 }
 
 /// This is not what you're looking for, see `array_swap`.
-static inline void _array__swap(uint32_t *self_size, uint32_t *self_capacity,
-                               uint32_t *other_size, uint32_t *other_capacity) {
-  uint32_t tmp_size = *self_size;
-  uint32_t tmp_capacity = *self_capacity;
-  *self_size = *other_size;
-  *self_capacity = *other_capacity;
-  *other_size = tmp_size;
-  *other_capacity = tmp_capacity;
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
 }
 
 /// This is not what you're looking for, see `array_push` or `array_grow_by`.
-static inline void *_array__grow(void *contents, uint32_t size, uint32_t *capacity,
-                               uint32_t count, size_t element_size) {
-  void *new_contents = contents;
-  uint32_t new_size = size + count;
-  if (new_size > *capacity) {
-    uint32_t new_capacity = *capacity * 2;
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
-    new_contents = _array__reserve(contents, capacity, element_size, new_capacity);
+    _array__reserve(self, element_size, new_capacity);
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_splice`.
-static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t *capacity,
-                                 size_t element_size,
+static inline void _array__splice(Array *self, size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = *size + new_count - old_count;
+  uint32_t new_size = self->size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= *size);
+  assert(old_end <= self->size);
 
-  void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
+  _array__reserve(self, element_size, new_size);
 
-  char *contents = (char *)new_contents;
-  if (*size > old_end) {
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
     memmove(
       contents + new_end * element_size,
       contents + old_end * element_size,
-      (*size - old_end) * element_size
+      (self->size - old_end) * element_size
     );
   }
   if (new_count > 0) {
@@ -287,9 +250,7 @@ static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t
       );
     }
   }
-  *size += new_count - old_count;
-
-  return new_contents;
+  self->size += new_count - old_count;
 }
 
 /// A binary search routine, based on Rust's `std::slice::binary_search_by`.


### PR DESCRIPTION
Currently if you try writing something along the lines of

```jai
cock := Balls.{ a.b = 420, c = 1337 };
```

the parser will produce a tree like this (anonymous nodes hidden):
```
...
struct_literal [0, 8] - [0, 37]
  type: identifier [0, 8] - [0, 13]
  parameter: member_expression [0, 16] - [0, 19]
    identifier [0, 16] - [0, 17]
    identifier [0, 18] - [0, 19]
  ERROR [0, 20] - [0, 25]
  name: identifier [0, 27] - [0, 28]
  parameter: integer [0, 31] - [0, 35]
```
with `ERROR` pointing at `= 420`.

with my changes the generated tree looks like:
```
...
struct_literal [0, 8] - [0, 37]
  type: identifier [0, 8] - [0, 13]
  name: member_expression [0, 16] - [0, 19]
    identifier [0, 16] - [0, 17]
    identifier [0, 18] - [0, 19]
  parameter: integer [0, 22] - [0, 25]
  name: identifier [0, 27] - [0, 28]
  parameter: integer [0, 31] - [0, 35]
```